### PR TITLE
payment: fix timeStamp -> timestamp

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -65,6 +65,9 @@ Payment.prototype.getBrandWCPayRequestParams = function (order, callback) {
       params.code_url = data.code_url;
     }
 
+    params.timestamp = params.timeStamp;
+    delete params.timeStamp;
+
     callback(null, params);
   });
 };


### PR DESCRIPTION
@supersheep see the latest [documentation](http://mp.weixin.qq.com/wiki/7/1c97470084b73f8e224fe6d9bab1625b.html#.E5.8F.91.E8.B5.B7.E4.B8.80.E4.B8.AA.E5.BE.AE.E4.BF.A1.E6.94.AF.E4.BB.98.E8.AF.B7.E6.B1.82), the `timestamp` in payload should be in lower case :-)