### PR TITLE
修复UnhandledPromiseRejection

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -504,7 +504,7 @@ if (global.Promise) {
             args.push(handleResult)
           } else {
             args[args.length - 1] = function (err, result) {
-              handleResult(err, result)
+              resolve(result)
               originCallback(err, result)
             }
           }


### PR DESCRIPTION
在Promise中同时调用handleResult和originCallback, 调用方需要同时处理两个地方的异常，可能导致UnhandledPromiseRejection, eg: 
`getBrandWCPayRequestParams: `
需要处理来自unifiedOrder的两个错误(callback and rejected promise), 只处理了callback
UnhandledPromiseRejection
`unifiedOrder:` ↑
只需要处理callback中的error
`_signedQuery:` ↑
需要处理来自validate的两个错误(callback and rejected promise), 只处理了callback
UnhandledPromiseRejection
`validate:` ↑
抛出错误
(总共有两个UnhandledPromiseRejection)